### PR TITLE
feat: support routing messages as custom events

### DIFF
--- a/minttea/event.ml
+++ b/minttea/event.ml
@@ -1,9 +1,10 @@
 open Riot
 
-type t = KeyDown of string | Timer of unit Ref.t | Frame
+type t = KeyDown of string | Timer of unit Ref.t | Frame | Custom of Message.t
 
 let pp fmt t =
   match t with
   | KeyDown key -> Format.fprintf fmt "KeyDown(%s)" key
   | Timer ref -> Format.fprintf fmt "Timer(%a)" Ref.pp ref
   | Frame -> Format.fprintf fmt "Frame"
+  | Custom _msg -> Format.fprintf fmt "Custom"

--- a/minttea/minttea.mli
+++ b/minttea/minttea.mli
@@ -1,7 +1,11 @@
 open Riot
 
 module Event : sig
-  type t = KeyDown of string | Timer of unit Ref.t | Frame
+  type t =
+    | KeyDown of string
+    | Timer of unit Ref.t
+    | Frame
+    | Custom of Message.t
 
   val pp : Format.formatter -> t -> unit
 end

--- a/minttea/program.ml
+++ b/minttea/program.ml
@@ -8,10 +8,13 @@ let make ~app ~fps = { app; fps }
 exception Exit
 
 let rec loop renderer (app : 'model App.t) (model : 'model) =
-  match receive () with
-  | Timer ref -> handle_input renderer app model (Event.Timer ref)
-  | Io_loop.Input event -> handle_input renderer app model event
-  | _ -> loop renderer app model
+  let event =
+    match receive () with
+    | Timer ref -> Event.Timer ref
+    | Io_loop.Input event -> event
+    | message -> Event.Custom message
+  in
+  handle_input renderer app model event
 
 and handle_input renderer app model event =
   let model, cmd = app.update event model in


### PR DESCRIPTION
Lets you send messages to the application process and receive them as custom events. This is needed to get data _into_ the TUI from other parts of the system that weren't started from within the TUI.

Some use-cases:
* If the TUI needs to send itself custom events it can do that directly with `send (self ()) The_message` or through timers with `Timer.send_after/send_interval`
* If the TUI is just one more Riot App, then other Riot apps can talk to it.