### PR TITLE
feat: better handle of escape sequences

### DIFF
--- a/minttea/event.ml
+++ b/minttea/event.ml
@@ -4,6 +4,6 @@ type t = KeyDown of string | Timer of unit Ref.t | Frame
 
 let pp fmt t =
   match t with
-  | KeyDown key -> Format.fprintf fmt "KeyDown(%s)" key
+  | KeyDown key -> Format.fprintf fmt "KeyDown(%S)" key
   | Timer ref -> Format.fprintf fmt "Timer(%a)" Ref.pp ref
   | Frame -> Format.fprintf fmt "Frame"

--- a/minttea/io_loop.ml
+++ b/minttea/io_loop.ml
@@ -4,13 +4,32 @@ open Tty
 
 type Message.t += Input of Event.t
 
-let translate = function " " -> "space" | key -> key
+let translate = function
+  | " " -> "<space>"
+  | "\027" -> "<esc>"
+  | "\027[A" -> "<up>"
+  | "\027[B" -> "<down>"
+  | "\027[C" -> "<left>"
+  | "\027[D" -> "<right>"
+  | "\127" -> "<backspace>"
+  | "\n" -> "<enter>"
+  | key -> key
 
 let rec loop runner =
   yield ();
   match Stdin.read_utf8 () with
   | `Read key ->
-      let msg = KeyDown (translate key) in
+      let msg =
+        match key with
+        | "\027" -> (
+            match Stdin.read_utf8 () with
+            | `Read "[" -> (
+                match Stdin.read_utf8 () with
+                | `Read key -> KeyDown (translate ("\027[" ^ key))
+                | _ -> KeyDown (translate key))
+            | _ -> KeyDown (translate key))
+        | key -> KeyDown (translate key)
+      in
       send runner (Input msg);
       loop runner
   | _ -> loop runner


### PR DESCRIPTION
Start translating more complex escape sequences into recognizable strings. Should fix #8 

The next steps from here would be to make this parsing more comprehensive, and turn the `KeyDown of string` variant into an enum where most common characters (enter, backspace, space, arrows, escape, shift, etc) are not strings. We can use strings for other text graphemes since we won't have variants for ñ, あ, or å, so we might as well not have 'em for "a" either.