### PR TITLE
feat(leaves): Add functor for defining user customizable keybindings

### DIFF
--- a/examples/key_map/dune
+++ b/examples/key_map/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries minttea spices leaves))

--- a/examples/key_map/main.ml
+++ b/examples/key_map/main.ml
@@ -1,0 +1,58 @@
+open Leaves
+open Minttea
+
+module Msg = struct
+  type t = CursorUp | CursorDown | CursorLeft
+
+  let defaults : (t * Key_map.binding) list =
+    [
+      ( CursorUp,
+        {
+          keys = [ Minttea.Event.Up; Minttea.Event.Key "k" ];
+          help = { key = "up"; desc = "↑/k" };
+          disabled = false;
+        } );
+      ( CursorDown,
+        {
+          keys = [ Minttea.Event.Down; Minttea.Event.Key "j" ];
+          help = { key = "down"; desc = "↓/j" };
+          disabled = false;
+        } );
+      ( CursorLeft,
+        {
+          keys = [ Minttea.Event.Left; Minttea.Event.Key "h" ];
+          help = { key = "left"; desc = "←/h" };
+          disabled = true;
+        } );
+    ]
+end
+
+module Test_key_map = Key_map.Make (Msg)
+
+let m =
+  Test_key_map.make
+    [
+      ( CursorUp,
+        {
+          keys = [ Minttea.Event.Up; Minttea.Event.Key "k" ];
+          help = { key = "up"; desc = "↑/k" };
+          disabled = false;
+        } );
+    ]
+
+let () =
+  List.iter
+    (fun k ->
+      match Test_key_map.find_match k m with
+      | Some CursorUp -> print_endline "up"
+      | Some CursorDown -> print_endline "down"
+      | Some CursorLeft -> print_endline "left"
+      | None -> print_endline "Not Found")
+    [
+      Event.Up;
+      Event.Key "k";
+      Event.Down;
+      Event.Key "j";
+      Event.Left;
+      Event.Enter;
+    ]

--- a/leaves/key_map.ml
+++ b/leaves/key_map.ml
@@ -1,0 +1,37 @@
+type help = { key : string; desc : string }
+type binding = { keys : Minttea.Event.key list; help : help; disabled : bool }
+
+module type Key_map_with_defaults = sig
+  type t
+
+  val defaults : (t * binding) list
+end
+
+module Make (K : Key_map_with_defaults) = struct
+  type t = (K.t * binding) list
+
+  let make bindings =
+    let f (default_msg, default_binding) bindings =
+      let is_bound = List.mem_assoc default_msg bindings in
+
+      if is_bound then bindings
+      else List.cons (default_msg, default_binding) bindings
+    in
+
+    List.fold_right f K.defaults bindings
+
+  let find_match key key_map =
+    let f (_, (binding : binding)) =
+      if binding.disabled then false
+      else List.exists (fun k -> k == key) binding.keys
+    in
+    List.find_opt f key_map |> Option.map (fun (msg, _) -> msg)
+
+  let update_binding msg f bindings =
+    let updated_binding = f (List.assoc_opt msg bindings) in
+
+    List.remove_assoc msg bindings |> List.cons (msg, updated_binding)
+
+  (* INFO: This is just incase the underlying type changes in refactorings *)
+  let to_list bindings = bindings
+end

--- a/leaves/key_map.mli
+++ b/leaves/key_map.mli
@@ -1,0 +1,18 @@
+type help = { key : string; desc : string }
+type binding = { keys : Minttea.Event.key list; help : help; disabled : bool }
+
+module type Key_map_with_defaults = sig
+  type t
+
+  val defaults : (t * binding) list
+end
+
+module Make : functor (K : Key_map_with_defaults) -> sig
+  type t = (K.t * binding) list
+
+  val make : (K.t * binding) list -> t
+  val find_match : Minttea.Event.key -> t -> K.t option
+  val update_binding : K.t -> (binding option -> binding) -> t -> t
+  val to_list : t -> (K.t * binding) list
+end
+


### PR DESCRIPTION
This method currently has the downside of not having any way to require that all bindings exist for the given variant type.