### PR TITLE
Changed alt screen rendering behaviour to avoid extra cleaned lines

### DIFF
--- a/minttea/renderer.ml
+++ b/minttea/renderer.ml
@@ -61,13 +61,13 @@ and flush t =
 
   (* clean last rendered lines *)
   if t.lines_rendered > 0 then
-    for _i = 1 to t.lines_rendered do
+    for _i = 1 to t.lines_rendered - 1 do
+      Terminal.clear_line ();
       Terminal.cursor_up 1;
-      Terminal.clear_line ()
     done;
 
   (* reset screen if its on alt *)
-  Format.printf "%s\r\n%!" t.buffer;
+  Format.printf "%s%!" t.buffer;
 
   if t.is_altscreen_active then Terminal.move_cursor new_lines_this_flush 0
   else Terminal.cursor_back t.width;


### PR DESCRIPTION
This PR aims to fix the bug reported in issue #6. Executing the alt-screen toogle example I understand than the unwanted behavior is the extra cleaned line / the extra new line that appears after alt mode exit

Former behaviour:

![former-demo](https://github.com/leostera/minttea/assets/16885588/fe030277-7ef8-4ebf-86d5-40076b770ed5)

New behaviour:

![new-demo](https://github.com/leostera/minttea/assets/16885588/226b7c56-86bb-443a-b384-d3b74c69e44c)

Bubble Tea behaviour:

![bubbletea-demo](https://github.com/charmbracelet/bubbletea/blob/master/examples/altscreen-toggle/altscreen-toggle.gif?raw=true)

If there is anything more to do please tell me, maybe I did not fully understand the issue