### PR TITLE
draft: Implemented some wrapping examples using shape the term package

### DIFF
--- a/examples/text-wrapping/dune
+++ b/examples/text-wrapping/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries minttea shape-the-term spices leaves))

--- a/examples/text-wrapping/main.ml
+++ b/examples/text-wrapping/main.ml
@@ -1,0 +1,44 @@
+open Minttea
+open Leaves
+
+type model = { text : Text_input.t; quitting : bool }
+
+let mint = Spices.color "#77e5b7"
+let white = Spices.color "#FFFFFF"
+
+let cursor =
+  Cursor.make ~style:Spices.(default |> bg mint |> fg white |> bold true) ()
+
+let initial_model =
+  {
+    text = Text_input.make "" ~placeholder:"Type something" ~cursor ();
+    quitting = false;
+  }
+
+let init _ = Command.Hide_cursor
+
+let update (event : Event.t) model =
+  let s =
+    match event with
+    | e ->
+        if e = Event.KeyDown (Enter, No_modifier) then
+          ({ model with quitting = true }, Command.Quit)
+        else
+          let text = Text_input.update model.text e in
+          ({ model with text }, Command.Noop)
+  in
+  s
+
+let view model =
+  let style = Spices.(default |> fg mint |> build) in
+  let width = 12 in 
+  let show s = Shape_the_term.wrap width @@ style "%s" s in 
+  if model.quitting then
+    Format.sprintf "\n🐫 Your text wrapped ✨ (to %s characters width):\n%s\n" (string_of_int width) 
+    @@ show @@ Text_input.current_text model.text
+  else 
+    Format.sprintf "\n🐫 Text area (%s characters width):\n%s\n" (string_of_int width)
+    @@ show @@ Text_input.view model.text
+
+let app = Minttea.app ~init ~update ~view ()
+let () = Minttea.start ~initial_model app

--- a/examples/word-wrapping/dune
+++ b/examples/word-wrapping/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries minttea shape-the-term spices leaves))

--- a/examples/word-wrapping/main.ml
+++ b/examples/word-wrapping/main.ml
@@ -1,0 +1,44 @@
+open Minttea
+open Leaves
+
+type model = { text : Text_input.t; quitting : bool }
+
+let mint = Spices.color "#77e5b7"
+let white = Spices.color "#FFFFFF"
+
+let cursor =
+  Cursor.make ~style:Spices.(default |> bg mint |> fg white |> bold true) ()
+
+let initial_model =
+  {
+    text = Text_input.make "" ~placeholder:"Type something" ~cursor ();
+    quitting = false;
+  }
+
+let init _ = Command.Hide_cursor
+
+let update (event : Event.t) model =
+  let s =
+    match event with
+    | e ->
+        if e = Event.KeyDown (Enter, No_modifier) then
+          ({ model with quitting = true }, Command.Quit)
+        else
+          let text = Text_input.update model.text e in
+          ({ model with text }, Command.Noop)
+  in
+  s
+
+let view model =
+  let style = Spices.(default |> fg mint |> build) in
+  let show width s = Shape_the_term.wrap_by_word width @@ style "%s" s in 
+  if model.quitting then
+    Format.sprintf "\n🐫 Your text wrapped by word ✨ (to 12 characters width):\n%s\n"
+    @@ show 12  @@ Text_input.current_text model.text
+  else 
+    (Format.sprintf "\n%s\n" @@ show 36 @@ Text_input.view model.text) ^
+    Format.sprintf "\n🐫 Wrap by word (to 12 characters width):\n%s\n"
+    @@ show 12 @@ Text_input.current_text model.text
+
+let app = Minttea.app ~init ~update ~view ()
+let () = Minttea.start ~initial_model app

--- a/minttea/minttea.ml
+++ b/minttea/minttea.ml
@@ -6,7 +6,7 @@ module Program = Program
 
 let app = App.make
 
-let run ?(fps = 60) ~initial_model app =
+let run ?(fps = 2) ~initial_model app =
   let prog = Program.make ~app ~fps in
   Program.run prog initial_model;
   Logger.trace (fun f -> f "terminating")


### PR DESCRIPTION
Opening this PR to include wrap and wrap by word showcases using https://github.com/jmcavanillas/shape-the-term

The examples are functional and ready for review but there are a couple of issues to address, 

To be completed / addressed before merging:

- [ ] If I do not set fps to a low value my computes just go BRRRRRR! :fire: and input starts to lag (actually maybe there is no solution yet for this as I think we will need a state diffing solution or similar)
- [ ] I have to pin the shape-the-term repo to main, I would like to include it as pin-depends but I have no idea yet
- [ ] Add VHS gifs 
- [ ] BONUS: Update readme example for Spices, there is no render function anymore