### PR TITLE
Bump riot to >= 0.0.9 in minttea.opam

### DIFF
--- a/minttea.opam
+++ b/minttea.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/leostera/minttea/issues"
 depends: [
   "dune" {>= "3.11"}
   "ocaml" {>= "5.1"}
-  "riot" {= "0.0.8"}
+  "riot" {>= "0.0.9"}
   "mdx" {with-test & >= "2.3.1"}
   "tty" {>= "0.0.2"}
   "uuseg"


### PR DESCRIPTION
The version is bumped inside `dune-project` but not in the `minttea.opam` file.

Because of this, when pinning the latest version of `minttea` from GitHub, I see the following error (which was very confusing to debug because it doesn't say which package has this strict constraint):

```
❯ opam switch create .
Package github_tui does not exist, create as a NEW package? [Y/n] y
The following additional pinnings are required by github_tui.~dev:
  - minttea.dev at git+https://github.com/leostera/minttea
  - riot.dev at git+https://github.com/riot-ml/riot
  - shape-the-term.dev at git+https://github.com/jmcavanillas/shape-the-term
Pin and install them? [Y/n] y
[minttea.dev] synchronised (no changes)
minttea is now pinned to git+https://github.com/leostera/minttea (version dev)
[riot.dev] synchronised (no changes)
riot is now pinned to git+https://github.com/riot-ml/riot (version dev)
Package shape-the-term does not exist, create as a NEW package? [Y/n] y
[shape-the-term.dev] synchronised (no changes)
shape-the-term is now pinned to git+https://github.com/jmcavanillas/shape-the-term (version dev)
github_tui is now pinned to git+file:///home/chshersh/ocaml/github-tui#chshersh/fix-ci (version ~dev)

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml" {>= "4.05.0"}]
[ERROR] Could not determine which packages to install for this switch:
  * Missing dependency:
    - riot = 0.0.8
    not available because the package is pinned to version dev


Switch initialisation failed: clean up? ('n' will leave the switch partially installed) [Y/n] y
```